### PR TITLE
Add zsh command completion function

### DIFF
--- a/zsh/_gitto
+++ b/zsh/_gitto
@@ -1,0 +1,73 @@
+#compdef gitto
+
+# gitto -- ZSH completion for gitto
+# Copyright (C) 2013 Benjamin Althues  <benjamin at babab dot nl>
+
+# This file is part of gitto.
+
+# gitto is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# gitto is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with gitto.  If not, see <http://www.gnu.org/licenses/>.
+
+local expl
+local -a repository_locations
+local -a _gitto_commands _gitto_config_commands _gitto_list_commands
+
+get_repository_locations() {
+  repository_locations=(${(f)"$(_call_program repository_locations \
+      gitto list locations 2>/dev/null)"})
+  _wanted repository_locations expl 'repository locations' \
+      compadd -a repository_locations
+}
+
+_gitto_commands=(
+  "add:register a new repository directory"
+  "check:check if a repository has been registered"
+  "config:show each repository's configuration"
+  "help:display help"
+  "list:list all repositories and their status"
+  "purge:remove all repositories that don't exist"
+  "remove:remove a repository directory"
+  "version:display version"
+)
+_gitto_config_commands=(
+  "global:show template configuration"
+  'hooks:install configured hooks for repositories'
+  "update:merge template configuration with each repository's configuration"
+)
+_gitto_list_commands=(
+  "locations:list all registered repositories' locations"
+)
+
+_arguments '*:: :->subcmds' && return 0
+
+if (( CURRENT == 1 )); then
+  _describe -t commands "gitto command" _gitto_commands
+  return 0
+fi
+
+case "$words[1]" in
+  add|check)
+    _files -/ &&  return 0 ;;
+  config)
+    _describe -t commands "gitto config command" _gitto_config_commands
+    return 0 ;;
+  help|purge|version)
+    return 0 ;;
+  list)
+    _describe -t commands "gitto list command" _gitto_list_commands
+    return 0 ;;
+  remove)
+    get_repository_locations && return 0
+esac
+
+# vim: set ft=zsh et ts=2 sw=2 sts=2:


### PR DESCRIPTION
Add completion for gitto (sub)commands and arguments for users of the Z shell.

Here is a little something to give back to the gitto project as a thank you for being such a cool tool. I did not bother to change the Makefiles to install the function in an appropiate location, e.g.: `/usr/share/zsh/site-functions`. Since I think that is something you'd prefer to add yourself and I am also not entirely sure if you like the current location `zsh/_gitto` in the project path.

Of course, let me know if there's something you'd like for me to change.
